### PR TITLE
fix: correct default values

### DIFF
--- a/src/host/cli-run-plan.js
+++ b/src/host/cli-run-plan.js
@@ -78,13 +78,13 @@ export const builder = (args = yargs) =>
         coerce(arg) {
           return new URL(arg);
         },
-        default: 'localhost:4444',
+        default: 'http://localhost:4444',
       },
       'agent-at-driver-url': {
         coerce(arg) {
           return new URL(arg);
         },
-        default: 'localhost:4382',
+        default: 'http://localhost:4382',
       },
       'agent-protocol': {
         choices: ['fork', 'developer'],


### PR DESCRIPTION
Prior to this commit, two command-line arguments which were documented
as URLs defaulted to string values that did not describe valid URLs.
Subsequent parsing would produce undesired behavior. For example:

    $ node -p 'new URL("localhost:4444").protocol'
    localhost:

Specify strings describing URLs for the arguments which are intended to
receive URLs.