### PR TITLE
fix: forward command-line arguments

### DIFF
--- a/src/host/agent.js
+++ b/src/host/agent.js
@@ -314,6 +314,8 @@ class AgentDeveloperProtocol extends AgentProtocol {
         baseUrl: options.referenceBaseUrl || new URL('http://localhost:4400'),
         log,
         mock: agentMockOptions(options),
+        atDriverUrl: options.atDriverUrl,
+        webDriverUrl: options.webDriverUrl,
       }),
       log,
       tests: iterateEmitter(this._testEmitter, 'message', 'stop'),


### PR DESCRIPTION
Provide values for non-optional parameters.