### PR TITLE
Handle timeout when waiting for page readiness

### DIFF
--- a/src/agent/driver-test-runner.js
+++ b/src/agent/driver-test-runner.js
@@ -68,14 +68,16 @@ export class DriverTestRunner {
           .then(callback);
       });
 
-      const runTestSetup = await this.webDriver.wait(
+      // TODO: Replace loaded and timeout race with a deterministic signal that
+      // the page is ready. This likely needs a change in aria-at's process.
+      const pageReady = Promise.race([loaded, timeout(AFTER_RUN_TEST_SETUP_BUTTON_DELAY)]);
+      const runTestButtonFound = this.webDriver.wait(
         until.elementLocated(By.className('button-run-test-setup')),
         RUN_TEST_SETUP_BUTTON_TIMEOUT
       );
-      // TODO: Replace loaded and timeout race with a deterministic signal that
-      // the page is ready. This likely needs a change in aria-at's process.
-      await Promise.race([loaded, timeout(AFTER_RUN_TEST_SETUP_BUTTON_DELAY)]);
-      await runTestSetup.click();
+      const [runTestButton] = await Promise.all([runTestButtonFound, pageReady]);
+
+      await runTestButton.click();
     } catch ({}) {
       await this.log(AgentMessage.NO_RUN_TEST_SETUP, { referencePage });
     }

--- a/src/agent/driver-test-runner.js
+++ b/src/agent/driver-test-runner.js
@@ -58,6 +58,7 @@ export class DriverTestRunner {
     await this.webDriver.navigate().to(url.toString());
 
     try {
+      const loadedTimeout = timeout(AFTER_RUN_TEST_SETUP_BUTTON_DELAY);
       const loaded = this.webDriver.executeAsyncScript(function (callback) {
         new Promise(resolve => {
           window.addEventListener('load', () => resolve());
@@ -68,9 +69,9 @@ export class DriverTestRunner {
           .then(callback);
       });
 
-      // TODO: Replace loaded and timeout race with a deterministic signal that
+      // TODO: Replace `loaded` and timeout with a deterministic signal that
       // the page is ready. This likely needs a change in aria-at's process.
-      const pageReady = Promise.race([loaded, timeout(AFTER_RUN_TEST_SETUP_BUTTON_DELAY)]);
+      const pageReady = loaded.catch(() => loadedTimeout);
       const runTestButtonFound = this.webDriver.wait(
         until.elementLocated(By.className('button-run-test-setup')),
         RUN_TEST_SETUP_BUTTON_TIMEOUT


### PR DESCRIPTION
Prior to this commit, if the Promise stored in the binding named `loaded` rejected while the WebDriver "wait" command was being evaluated, that rejection would trigger a Node.js global "unhandled rejection" error and cause the process to crash.

Track all Promise values so that a rejection in any of them at any time is handled by the caller.