### PR TITLE
support command.settings (mode switch) for v2 tests

### DIFF
--- a/src/agent/driver-test-runner.js
+++ b/src/agent/driver-test-runner.js
@@ -140,7 +140,7 @@ export class DriverTestRunner {
     } else if (!atName) {
       return;
     }
-    throw new Error(`Unable to ensure proper settings. Unknown atName ${capabilities.atName}`);
+    throw new Error(`Unable to ensure proper settings. Unknown atName ${atName}`);
   }
 
   /**

--- a/src/agent/driver-test-runner.js
+++ b/src/agent/driver-test-runner.js
@@ -187,7 +187,7 @@ export class DriverTestRunner {
           // Ensure AT is in proper mode for tests.  V2 tests define "settings" per command.
           await this.ensureSettings(command.settings);
         } else if (test.target?.mode) {
-          // V1 tests define a "mode" of "reading" or "interactive" on the test.target
+          // V1 tests define a "mode" of "reading" or "interaction" on the test.target
           await this.ensureMode(test.target.mode);
         }
 

--- a/src/agent/driver-test-runner.js
+++ b/src/agent/driver-test-runner.js
@@ -91,7 +91,7 @@ export class DriverTestRunner {
   }
 
   /**
-   * Used for v2 aria-at tests, "reading" and "interactive" map to various settings based on AT.
+   * Used for v2 tests to ensure proper settings.
    *
    * @param {string} settings - "browseMode" "focusMode" for NVDA, "pcCursor" "virtualCursor"
    *                 for JAWS., "defaultMode" for others.
@@ -118,8 +118,7 @@ export class DriverTestRunner {
           speechResponse = await this._collectSpeech(MODE_SWITCH_SPEECH_TIMEOUT, () =>
             this.sendKeys(ATKey.sequence(ATKey.chord(ATKey.key('insert'), ATKey.key('space'))))
           );
-          // convert from array of strings to single string and trim begin/end whitespace
-          speechResponse = speechResponse.join(' ').replace(/^\s+|\s+$/g, '');
+          speechResponse = speechResponse.join(' ').trim();
           if (speechResponse.toLowerCase() === desiredResponse.toLowerCase()) {
             // our mode is correct, we are done
             return;
@@ -150,7 +149,8 @@ export class DriverTestRunner {
   async ensureMode(mode) {
     const { atName } = await this.collectedCapabilities;
     if (atName === 'NVDA') {
-      return this.ensureSettings(mode.toLowerCase() === 'reading' ? 'browseMode' : 'focusMode');
+      await this.ensureSettings(mode.toLowerCase() === 'reading' ? 'browseMode' : 'focusMode');
+      return;
     } else if (!atName) {
       return;
     }

--- a/src/agent/driver-test-runner.js
+++ b/src/agent/driver-test-runner.js
@@ -149,7 +149,7 @@ export class DriverTestRunner {
    */
   async ensureMode(mode) {
     const { atName } = await this.collectedCapabilities;
-    if (atName == 'NVDA') {
+    if (atName === 'NVDA') {
       return this.ensureSettings(mode.toLowerCase() === 'reading' ? 'browseMode' : 'focusMode');
     } else if (!atName) {
       return;


### PR DESCRIPTION
V2 tests define a `settings` on each command that choses between one of the settings defined for the AT.  Current definitions look something like this (taken from `target.ats` of a combined.json):

```json
    "ats": [
      {
        "key": "jaws",
        "settings": "virtualCursor",
        "name": "JAWS"
      },
      {
        "key": "jaws",
        "settings": "pcCursor",
        "name": "JAWS"
      },
      {
        "key": "nvda",
        "settings": "browseMode",
        "name": "NVDA"
      },
      {
        "key": "nvda",
        "settings": "focusMode",
        "name": "NVDA"
      },
      {
        "key": "voiceover_macos",
        "settings": "defaultMode",
        "name": "VoiceOver for macOS"
      }
    ],
```

A command then looks like this:

```json
  "commands": [
    {
      "id": "space",
      "keypresses": [
        {
          "id": "space",
          "keystroke": "Space"
        }
      ],
      "assertionExceptions": [],
      "keystroke": "Space",
      "presentationNumber": 1,
      "settings": "virtualCursor"
    },
```

--- 

This implementation has one method for the "settings" path for new system and maintains the old "mode" path (`target.mode` on the collected.json) - converting the "reading" -> "browseMode" and "interaction" -> "focusMode" for NVDA