### PR TITLE
Adding eol=lf to .gitattributes for js/json/md files.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.md text eol=lf
+*.js text eol=lf
+*.json text eol=lf


### PR DESCRIPTION
Just in case other windows based developers run into the crlf issue later.