### PR TITLE
Add specific messages for thrown errors in web-driver and at-driver

### DIFF
--- a/src/agent/at-driver.js
+++ b/src/agent/at-driver.js
@@ -31,7 +31,11 @@ export class ATDriver {
   constructor({ socket, log }) {
     this.socket = socket;
     this.log = log;
-    this.ready = new Promise(resolve => socket.once('open', () => resolve())).then(() =>
+    const connected = new Promise((resolve, reject) => {
+      socket.once('open', () => resolve());
+      socket.once('error', err => reject(err));
+    });
+    this.ready = connected.then(() =>
       this._send({ method: 'session.new', params: { capabilities: {} } }).then(
         ({ result: { capabilities } }) => {
           this._capabilities = capabilities;

--- a/src/agent/create-test-runner.js
+++ b/src/agent/create-test-runner.js
@@ -44,7 +44,7 @@ export async function createRunner(options) {
       abortSignal: options.abortSignal,
       log: options.log,
     }).catch(cause => {
-      throw new Error('Rrror connecting to at-driver', { cause });
+      throw new Error('Error connecting to at-driver', { cause });
     }),
   ]);
   return new DriverTestRunner({ ...options, webDriver, atDriver });

--- a/src/agent/create-test-runner.js
+++ b/src/agent/create-test-runner.js
@@ -36,15 +36,15 @@ export async function createRunner(options) {
       browser: options.webDriverBrowser,
       abortSignal: options.abortSignal,
       log: options.log,
-    }).catch(err => {
-      throw new Error(`Error connecting to web-driver: ${err}`);
+    }).catch(cause => {
+      throw new Error('Error connecting to web-driver', { cause });
     }),
     createATDriver({
       url: options.atDriverUrl,
       abortSignal: options.abortSignal,
       log: options.log,
-    }).catch(err => {
-      throw new Error(`Error connecting to at-driver: ${err}`);
+    }).catch(cause => {
+      throw new Error('Rrror connecting to at-driver', { cause });
     }),
   ]);
   return new DriverTestRunner({ ...options, webDriver, atDriver });

--- a/src/agent/create-test-runner.js
+++ b/src/agent/create-test-runner.js
@@ -36,11 +36,15 @@ export async function createRunner(options) {
       browser: options.webDriverBrowser,
       abortSignal: options.abortSignal,
       log: options.log,
+    }).catch(err => {
+      throw new Error(`Error connecting to web-driver: ${err}`);
     }),
     createATDriver({
       url: options.atDriverUrl,
       abortSignal: options.abortSignal,
       log: options.log,
+    }).catch(err => {
+      throw new Error(`Error connecting to at-driver: ${err}`);
     }),
   ]);
   return new DriverTestRunner({ ...options, webDriver, atDriver });


### PR DESCRIPTION
Just trying to be a bit more clear on where the error is happening, both of these errors were thrown deep inside libraries (ws/webdriver) previously, rethrowing from our own code gives us some hope of tracking down where in the repository the error flow happens.