### PR TITLE
Enforce types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,11 +21,14 @@
         "aria-at-harness-host": "bin/host.js"
       },
       "devDependencies": {
+        "@types/node": "^20.8.10",
+        "@types/text-encoding": "^0.0.38",
         "ava": "^4.1.0",
         "husky": "^7.0.2",
         "jsdoc": "^3.6.7",
         "lint-staged": "^11.2.3",
-        "prettier": "^2.4.1"
+        "prettier": "^2.4.1",
+        "typescript": "^5.3.3"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -181,10 +184,25 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@types/node": {
+      "version": "20.8.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.10.tgz",
+      "integrity": "sha512-TlgT8JntpcbmKUFzjhsyhGfP2fsiz1Mv56im6enJ905xG1DAYesxJaeSbGqQmAw8OWPdhyJGhGSQGKRNJ45u9w==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
+      "dev": true
+    },
+    "node_modules/@types/text-encoding": {
+      "version": "0.0.38",
+      "resolved": "https://registry.npmjs.org/@types/text-encoding/-/text-encoding-0.0.38.tgz",
+      "integrity": "sha512-S2RxbpiiSWjBDY8mjNTnX5RiOgGP0EIf3raU/Bvc3Djdt/pbiRTAxQfIypHJwVmt92dsMdIjlja5I143zDBdMw==",
       "dev": true
     },
     "node_modules/accepts": {
@@ -3537,6 +3555,19 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typescript": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/uc.micro": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
@@ -3547,6 +3578,12 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
       "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==",
+      "dev": true
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true
     },
     "node_modules/unpipe": {

--- a/package.json
+++ b/package.json
@@ -8,11 +8,14 @@
     "aria-at-harness-host": "./bin/host.js"
   },
   "devDependencies": {
+    "@types/node": "^20.8.10",
+    "@types/text-encoding": "^0.0.38",
     "ava": "^4.1.0",
     "husky": "^7.0.2",
     "jsdoc": "^3.6.7",
     "lint-staged": "^11.2.3",
-    "prettier": "^2.4.1"
+    "prettier": "^2.4.1",
+    "typescript": "^5.3.3"
   },
   "dependencies": {
     "express": "^4.17.1",
@@ -29,7 +32,8 @@
   "scripts": {
     "build": "npm run build:docs",
     "build:docs": "jsdoc src -r -d docs",
-    "test": "npm run test:unit",
+    "test": "npm run test:types && npm run test:unit",
+    "test:types": "tsc",
     "test:unit": "ava",
     "postinstall": "husky install"
   },

--- a/src/@types/global.d.ts
+++ b/src/@types/global.d.ts
@@ -1,0 +1,11 @@
+// The `fetch-blob` module internally relies on a type named File which it does
+// not define:
+//
+// Define a type for the "File" object globally so that it available when the
+// TypeScript compiler inspects that module's type definitions.
+
+export {};
+
+declare global {
+  type File = typeof import('fetch-blob/file.js');
+}

--- a/src/agent/at-driver.js
+++ b/src/agent/at-driver.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import ws from 'ws';
 
 import { iterateEmitter } from '../shared/iterate-emitter.js';

--- a/src/agent/cli.js
+++ b/src/agent/cli.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /// <reference path="types.js" />
 
 /**

--- a/src/agent/create-test-runner.js
+++ b/src/agent/create-test-runner.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /// <reference path="../shared/types.js" />
 /// <reference path="types.js" />
 

--- a/src/agent/driver-test-runner.js
+++ b/src/agent/driver-test-runner.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /// <reference path="../data/types.js" />
 /// <reference path="../shared/types.js" />
 /// <reference path="types.js" />

--- a/src/agent/index.js
+++ b/src/agent/index.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * @module agent
  */

--- a/src/agent/mock-test-runner.js
+++ b/src/agent/mock-test-runner.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /// <reference path="../data/types.js" />
 /// <reference path="../shared/types.js" />
 /// <reference path="types.js" />

--- a/src/agent/types.js
+++ b/src/agent/types.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /// <reference path="../data/types.js" />
 /// <reference path="../shared/types.js" />
 

--- a/src/host/agent.js
+++ b/src/host/agent.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /// <reference path="../data/types.js" />
 /// <reference path="../shared/types.js" />
 /// <reference path="types.js" />

--- a/src/host/cli-read-plan.js
+++ b/src/host/cli-read-plan.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * @module host
  */

--- a/src/host/cli-run-plan.js
+++ b/src/host/cli-run-plan.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * @module host
  */

--- a/src/host/cli.js
+++ b/src/host/cli.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /// <reference path="./types.js" />
 
 /**

--- a/src/host/index.js
+++ b/src/host/index.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * @module host
  */

--- a/src/host/main.js
+++ b/src/host/main.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /// <reference path="types.js" />
 
 /**

--- a/src/host/messages.js
+++ b/src/host/messages.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /// <reference path="types.js" />
 
 /**

--- a/src/host/plan-from.js
+++ b/src/host/plan-from.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /// <reference path="../shared/file-record-types.js" />
 /// <reference path="types.js" />
 

--- a/src/host/plan-object.js
+++ b/src/host/plan-object.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /// <reference path="../shared/file-record.js" />
 /// <reference path="types.js" />
 

--- a/src/host/server.js
+++ b/src/host/server.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /// <reference path="types.js" />
 
 /**

--- a/src/host/tests/agent.js
+++ b/src/host/tests/agent.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /// <reference path="../../data/types.js" />
 
 import test from 'ava';

--- a/src/host/tests/cli-run-plan.js
+++ b/src/host/tests/cli-run-plan.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { exec } from 'child_process';
 import path from 'path';
 import { fileURLToPath } from 'url';

--- a/src/host/tests/messages.js
+++ b/src/host/tests/messages.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import test from 'ava';
 
 import { HostMessage, createHostLogger } from '../messages.js';

--- a/src/host/tests/plan-from.js
+++ b/src/host/tests/plan-from.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /// <reference path="../types.js"/>
 
 import path from 'path';

--- a/src/host/tests/plan-object.js
+++ b/src/host/tests/plan-object.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import test from 'ava';
 
 import * as planObject from '../plan-object.js';

--- a/src/host/types.js
+++ b/src/host/types.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /// <reference path="../data/types.js" />
 /// <reference path="../shared/file-record.js" />
 /// <reference path="../shared/types.js" />

--- a/src/shared/file-record-types.js
+++ b/src/shared/file-record-types.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * @namespace FileRecord
  */

--- a/src/shared/file-record.js
+++ b/src/shared/file-record.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /// <reference path="./file-record-types.js" />
 
 /**

--- a/src/shared/iterate-emitter.js
+++ b/src/shared/iterate-emitter.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * @module shared
  */

--- a/src/shared/job.js
+++ b/src/shared/job.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /// <reference path="types.js" />
 
 /**

--- a/src/shared/messages.js
+++ b/src/shared/messages.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /// <reference path="./types.js" />
 
 /**

--- a/src/shared/tests/file-record.js
+++ b/src/shared/tests/file-record.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';

--- a/src/shared/tests/iterate-emitter.js
+++ b/src/shared/tests/iterate-emitter.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { EventEmitter } from 'events';
 
 import test from 'ava';

--- a/src/shared/types.js
+++ b/src/shared/types.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /** @namespace AriaATCIShared */
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "checkJs": true,
+    "noEmit": true,
+    "target": "ES6",
+    "module": "es2020",
+    "moduleResolution": "node",
+    "lib": ["es2018"]
+  },
+  "include": ["src/**/*"],
+  "exclude": [
+    "src/shared/tests/fixtures"
+  ]
+}


### PR DESCRIPTION
- Formalize the project's dependency on the TypeScript compiler
- Configure the TypeScript compiler to verify types in JavaScript source code
- Introduce a type definition for an external library as a work-around for a known issue in that library.
- Explicitly ignore all source files with errors in their type definitions (to be incrementally removed as the source files are corrected over time)