### PR TITLE
Drop support for Node.js version 16

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -17,7 +17,6 @@ jobs:
       matrix:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
         node-version:
-          - 16.x
           - 18.x
           - 20.x
         os: [ubuntu-latest, windows-latest]

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "yargs": "^17.2.1"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "homepage": "https://github.com/bocoup/aria-at-harness",
   "scripts": {


### PR DESCRIPTION
Version 16 reached end-of-life on 2023-09-11

https://nodejs.org/en/blog/announcements/nodejs16-eol/