### PR TITLE
fix a path building issue

### DIFF
--- a/src/agent/driver-test-runner.js
+++ b/src/agent/driver-test-runner.js
@@ -279,8 +279,8 @@ export class DriverTestRunner {
   _appendBaseUrl(pathname) {
     // protocol ends with a ':' and pathname starts with a '/'
     const base = `${this.baseUrl.protocol}//${this.baseUrl.hostname}:${this.baseUrl.port}${this.baseUrl.pathname}`;
-    const urlPart = `${this.baseUrl.pathname ? `${this.baseUrl.pathname}/` : ''}${pathname}`;
-    return new URL(`${this.baseUrl.pathname ? `${this.baseUrl.pathname}/` : ''}${pathname}`, base);
+    const newPath = `${this.baseUrl.pathname ? `${this.baseUrl.pathname}/` : ''}${pathname}`;
+    return new URL(newPath, base);
   }
 }
 

--- a/src/agent/driver-test-runner.js
+++ b/src/agent/driver-test-runner.js
@@ -277,7 +277,9 @@ export class DriverTestRunner {
   }
 
   _appendBaseUrl(pathname) {
-    const base = `${this.baseUrl.protocol}://${this.baseUrl.hostname}:${this.baseUrl.port}/${this.baseUrl.pathname}`;
+    // protocol ends with a ':' and pathname starts with a '/'
+    const base = `${this.baseUrl.protocol}//${this.baseUrl.hostname}:${this.baseUrl.port}${this.baseUrl.pathname}`;
+    const urlPart = `${this.baseUrl.pathname ? `${this.baseUrl.pathname}/` : ''}${pathname}`;
     return new URL(`${this.baseUrl.pathname ? `${this.baseUrl.pathname}/` : ''}${pathname}`, base);
   }
 }


### PR DESCRIPTION
I think this might've snuck in with the latest TSC stuff but I ran into an error of "Invalid URL" when trying to run latest main on my machine.

noticed there was a doubled `:` and `/` in the base url here `http:://127.0.0.1:1234//url` is what it looked like