### PR TITLE
Fix: NVDA ensureSettings path not throwing unkown atName

### DIFF
--- a/src/agent/driver-test-runner.js
+++ b/src/agent/driver-test-runner.js
@@ -121,7 +121,7 @@ export class DriverTestRunner {
       });
 
       try {
-        await this.pressKeysToToggleSetting(
+        return await this.pressKeysToToggleSetting(
           ATKey.sequence(ATKey.chord(ATKey.key('insert'), ATKey.key('space'))),
           desiredResponse
         );

--- a/src/agent/driver-test-runner.js
+++ b/src/agent/driver-test-runner.js
@@ -121,7 +121,7 @@ export class DriverTestRunner {
       });
 
       try {
-        return await this.pressKeysToToggleSetting(
+        await this.pressKeysToToggleSetting(
           ATKey.sequence(ATKey.chord(ATKey.key('insert'), ATKey.key('space'))),
           desiredResponse
         );
@@ -161,8 +161,9 @@ export class DriverTestRunner {
       return;
     } else if (!atName) {
       return;
+    } else {
+      throw new Error(`Unable to ensure proper settings. Unknown atName ${atName}`);
     }
-    throw new Error(`Unable to ensure proper settings. Unknown atName ${atName}`);
   }
 
   /**


### PR DESCRIPTION
Without a return here the code path drops through and throws `Unable to ensure proper settings. Unknown atName NVDA`