### PR TITLE
Publish to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "aria-at-automation-harness",
-  "version": "0.0.0",
-  "private": true,
+  "version": "0.0.1",
   "type": "module",
   "bin": {
     "aria-at-harness-agent": "./bin/agent.js",


### PR DESCRIPTION
Historically, consumers have retrieveed the code in this project using Git. Publishing to npm will allow maintainers to explicitly designate releases and annotate those releases using Semantic Versioning.