### PR TITLE
simple fix for duplicate logs

### DIFF
--- a/src/runner/at-driver.js
+++ b/src/runner/at-driver.js
@@ -32,6 +32,10 @@ export class ATDriver {
   constructor({ socket, log }) {
     this.socket = socket;
     this.log = log;
+    socket.on('message', rawMessage => {
+      const message = rawMessage.toString();
+      this.log(RunnerMessage.AT_DRIVER_COMMS, { direction: 'inbound', message });
+    });
     const connected = new Promise((resolve, reject) => {
       socket.once('open', () => resolve());
       socket.once('error', err => reject(err));
@@ -69,7 +73,6 @@ export class ATDriver {
     if (this.hasClosed) throw new Error('AT-Driver connection unexpectedly closed');
     for await (const rawMessage of iterateEmitter(this.socket, 'message', 'close', 'error')) {
       const message = rawMessage.toString();
-      this.log(RunnerMessage.AT_DRIVER_COMMS, { direction: 'inbound', message });
       yield JSON.parse(message);
     }
   }


### PR DESCRIPTION
This just moves the invocation of the log method to an event listener bound directly on the runner class.

I did some further testing of the async generator loop for `_messages` and I do believe that the event emitters are being bound/cleaned up properly by the `iterateEmitter` helper.  It's definitely doing some black magic iterator/generator voodoo, but it does appear to result in only 1-3 of these emitters existing at the same time.  Things are being cleaned up by the `return()` method given this bit from the MDN docs:

> If the for...of loop exited early (e.g. a break statement is encountered or an error is thrown), the [return()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterator_protocol) method of the iterator is called to perform any cleanup.