### PR TITLE
converts desired AT setting responses to arrays

### DIFF
--- a/src/runner/driver-test-runner.js
+++ b/src/runner/driver-test-runner.js
@@ -12,6 +12,7 @@ export const NVDASettingResponses = {
   focusMode: ['Focus mode'],
 };
 
+// Supports known setting responses up to macOS 15.4.1
 export const VOSettingResponses = {
   quickNavOn: ['Quick nav on', 'All quick nav on'],
   quickNavOff: ['Quick nav off', 'All quick nav off'],

--- a/src/runner/tests/driver-test-runner.js
+++ b/src/runner/tests/driver-test-runner.js
@@ -1,0 +1,54 @@
+import test from 'ava';
+
+import {
+  NVDASettingResponses,
+  VOSettingResponses,
+  isDesiredSettingResponse,
+} from '../driver-test-runner.js';
+
+test('isDesiredSettingResponse', t => {
+  // NVDA
+  t.true(
+    isDesiredSettingResponse('BROwse ModE', NVDASettingResponses.browseMode),
+    'handles casing'
+  );
+
+  t.true(isDesiredSettingResponse('Browse Mode', NVDASettingResponses.browseMode));
+
+  t.false(isDesiredSettingResponse('Focus Mode', NVDASettingResponses.browseMode));
+
+  t.true(isDesiredSettingResponse('Focus Mode', NVDASettingResponses.focusMode));
+
+  t.false(isDesiredSettingResponse('Browse Mode', NVDASettingResponses.focusMode));
+
+  // Voiceover
+  t.true(isDesiredSettingResponse('QUIck NaV ON', VOSettingResponses.quickNavOn), 'handles casing');
+
+  t.true(isDesiredSettingResponse('quick nav on', VOSettingResponses.quickNavOn));
+
+  t.true(isDesiredSettingResponse('All quick nav on', VOSettingResponses.quickNavOn));
+
+  t.false(isDesiredSettingResponse('All quick nav off', VOSettingResponses.quickNavOn));
+
+  t.true(isDesiredSettingResponse('quick nav off', VOSettingResponses.quickNavOff));
+
+  t.true(isDesiredSettingResponse('All quick nav off', VOSettingResponses.quickNavOff));
+
+  t.false(isDesiredSettingResponse('All quick nav on', VOSettingResponses.quickNavOff));
+
+  t.true(
+    isDesiredSettingResponse('Single-key quick nav on', VOSettingResponses.singleKeyQuickNavOn)
+  );
+
+  t.false(
+    isDesiredSettingResponse('Single-key quick nav off', VOSettingResponses.singleKeyQuickNavOn)
+  );
+
+  t.true(
+    isDesiredSettingResponse('Single-key quick nav off', VOSettingResponses.singleKeyQuickNavOff)
+  );
+
+  t.false(
+    isDesiredSettingResponse('Single-key quick nav on', VOSettingResponses.singleKeyQuickNavOff)
+  );
+});

--- a/src/runner/tests/driver-test-runner.js
+++ b/src/runner/tests/driver-test-runner.js
@@ -1,54 +1,11 @@
 import test from 'ava';
 
-import {
-  NVDASettingResponses,
-  VOSettingResponses,
-  isDesiredSettingResponse,
-} from '../driver-test-runner.js';
+import { isDesiredSettingResponse } from '../driver-test-runner.js';
 
 test('isDesiredSettingResponse', t => {
-  // NVDA
-  t.true(
-    isDesiredSettingResponse('BROwse ModE', NVDASettingResponses.browseMode),
-    'handles casing'
-  );
+  t.true(isDesiredSettingResponse('BROwse ModE', ['Browse mode']), 'handles casing');
 
-  t.true(isDesiredSettingResponse('Browse Mode', NVDASettingResponses.browseMode));
+  t.true(isDesiredSettingResponse('quick nav on', ['Quick nav on', 'All quick nav on']));
 
-  t.false(isDesiredSettingResponse('Focus Mode', NVDASettingResponses.browseMode));
-
-  t.true(isDesiredSettingResponse('Focus Mode', NVDASettingResponses.focusMode));
-
-  t.false(isDesiredSettingResponse('Browse Mode', NVDASettingResponses.focusMode));
-
-  // Voiceover
-  t.true(isDesiredSettingResponse('QUIck NaV ON', VOSettingResponses.quickNavOn), 'handles casing');
-
-  t.true(isDesiredSettingResponse('quick nav on', VOSettingResponses.quickNavOn));
-
-  t.true(isDesiredSettingResponse('All quick nav on', VOSettingResponses.quickNavOn));
-
-  t.false(isDesiredSettingResponse('All quick nav off', VOSettingResponses.quickNavOn));
-
-  t.true(isDesiredSettingResponse('quick nav off', VOSettingResponses.quickNavOff));
-
-  t.true(isDesiredSettingResponse('All quick nav off', VOSettingResponses.quickNavOff));
-
-  t.false(isDesiredSettingResponse('All quick nav on', VOSettingResponses.quickNavOff));
-
-  t.true(
-    isDesiredSettingResponse('Single-key quick nav on', VOSettingResponses.singleKeyQuickNavOn)
-  );
-
-  t.false(
-    isDesiredSettingResponse('Single-key quick nav off', VOSettingResponses.singleKeyQuickNavOn)
-  );
-
-  t.true(
-    isDesiredSettingResponse('Single-key quick nav off', VOSettingResponses.singleKeyQuickNavOff)
-  );
-
-  t.false(
-    isDesiredSettingResponse('Single-key quick nav on', VOSettingResponses.singleKeyQuickNavOff)
-  );
+  t.false(isDesiredSettingResponse('quick nav', ['Quick nav on', 'All quick nav on']));
 });


### PR DESCRIPTION
Implements suggested fix for #83 

I still wonder if there's a more durable way to get a report of mode settings from the AT via AT driver, but this should cover any OS/AT version-level changes to the expected responses for now. 

I tested this locally with macOS 15.4.1  but would appreciate if someone could manually test with NVDA! 🙏🏽 