### PR TITLE
Jaws confirm setting of virtual pc cursor

### DIFF
--- a/src/runner/driver-test-runner.js
+++ b/src/runner/driver-test-runner.js
@@ -197,7 +197,20 @@ export class DriverTestRunner {
           throw new Error(`Unknown command setting for JAWS "${setting}"`);
         }
 
-        // intentionally set the wrong mode first
+        // Two "setSettings" commands are needed to safely bring JAWS to a
+        // known state. This is because JAWS does not vocalize a response to
+        // set a setting which is already in effect. This presents a problem
+        // for the harness because it must consume all state-related
+        // vocalizations so that they do not leak into the output collected by
+        // whatever test is to follow. By setting the *undesired* value
+        // followed by the desired value, the harness can deterministically
+        // consume all such vocalizations.
+        //
+        // When JAWS supports the "getSettings" command, this logic should be
+        // simplified to first check the current state and only issue a
+        // "setSettings" command (for the desired value) when necessary.
+        //
+        // https://github.com/w3c/aria-at-automation-harness/issues/91
         await this.atDriver._send({
           method: 'settings.setSettings',
           params: {

--- a/src/runner/driver-test-runner.js
+++ b/src/runner/driver-test-runner.js
@@ -196,6 +196,20 @@ export class DriverTestRunner {
         if (!value) {
           throw new Error(`Unknown command setting for JAWS "${setting}"`);
         }
+        // check if we are already in the correct mode
+        const getSettingsResponse = await this.atDriver._send({
+          method: 'settings.getSettings',
+          params: {
+            settings: [{ name: 'cursor' }],
+          },
+        });
+        console.log(`Settings Response ${getSettingsResponse}`);
+        const {
+          result: { settings },
+        } = getSettingsResponse;
+        if (settings.any(s => s.name == 'cursor' && s.value === value)) return;
+
+        // if we weren't change mode and wait for the vocalization of the setting change
         let unknownCollected = '';
         const speechResponse = await this._collectSpeech(this.timesOption.modeSwitch, () =>
           this.atDriver._send({

--- a/src/runner/driver-test-runner.js
+++ b/src/runner/driver-test-runner.js
@@ -225,7 +225,6 @@ export class DriverTestRunner {
           },
         });
 
-        // if we weren't change mode and wait for the vocalization of the setting change
         let unknownCollected = '';
         const speechResponse = await this._collectSpeech(this.timesOption.modeSwitch, () =>
           this.atDriver._send({

--- a/src/runner/driver-test-runner.js
+++ b/src/runner/driver-test-runner.js
@@ -196,18 +196,21 @@ export class DriverTestRunner {
         if (!value) {
           throw new Error(`Unknown command setting for JAWS "${setting}"`);
         }
-        // check if we are already in the correct mode
-        const getSettingsResponse = await this.atDriver._send({
-          method: 'settings.getSettings',
+
+        // intentionally set the wrong mode first
+        await this.atDriver._send({
+          method: 'settings.setSettings',
           params: {
-            settings: [{ name: 'cursor' }],
+            settings: [
+              {
+                name: 'cursor',
+                value: ARIA_AT_TO_JAWS_CURSOR_SETTING_VALUE.get(
+                  setting == 'virtualCursor' ? 'pcCursor' : 'virtualCursor'
+                ),
+              },
+            ],
           },
         });
-        console.log(`Settings Response ${getSettingsResponse}`);
-        const {
-          result: { settings },
-        } = getSettingsResponse;
-        if (settings.any(s => s.name == 'cursor' && s.value === value)) return;
 
         // if we weren't change mode and wait for the vocalization of the setting change
         let unknownCollected = '';


### PR DESCRIPTION
@jugglinmike This does the "wrong setting first" approach, but without the last commit, it had the "getSettings" approach, so we could revert d6273ad482ae20c2089f326daf3e9e2c5feb8291 later when getSettings support is added to JAWS

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210763607230188