### PR TITLE
Temporary fix for jaws double escape

### DIFF
--- a/src/runner/driver-test-runner.js
+++ b/src/runner/driver-test-runner.js
@@ -347,8 +347,14 @@ export class DriverTestRunner {
    */
   async _collectSpeech(debounceDelay, asyncOperation) {
     let spoken = [];
+    const isJAWS = (await this.collectedCapabilities).atName == 'JAWS';
+
     const speechJob = startJob(async signal => {
-      for await (const speech of signal.cancelable(this.atDriver.speeches())) {
+      for await (let speech of signal.cancelable(this.atDriver.speeches())) {
+        if (isJAWS) {
+          // temporary workaround to double-escaped string literals.
+          speech = JSON.parse(`"${speech}"`);
+        }
         spoken.push(speech);
         this.log(RunnerMessage.SPEECH_EVENT, { spokenText: speech });
       }


### PR DESCRIPTION
Very hacky (but temporary) workaround to the double-escaped output coming from JAWS.

From some testing https://github.com/gnarf/aria-at-gh-actions-helper/actions/runs/16275760302/job/45954147908

```
AT-Driver: inbound: {"method":"interaction.capturedOutput","params":{"sessionId":"a3af441b-85e8-46b4-85fc-9fd1e69a95c7","data":" \\u001d MainRegion \\u001e "}}
AT-Driver: inbound: {"method":"interaction.capturedOutput","params":{"sessionId":"a3af441b-85e8-46b4-85fc-9fd1e69a95c7","data":""}}
AT-Driver: inbound: {"method":"interaction.capturedOutput","params":{"sessionId":"a3af441b-85e8-46b4-85fc-9fd1e69a95c7","data":"Run Test Setup  \\u001d Button \\u001e  "}}
AT-Driver: inbound: {"method":"interaction.capturedOutput","params":{"sessionId":"a3af441b-85e8-46b4-85fc-9fd1e69a95c7","data":"To activate press spacebar."}}
Speech event: '  MainRegion  '.
Speech event: ''.
Speech event: 'Run Test Setup   Button   '.
Speech event: 'To activate press spacebar.'.
```