### PR TITLE
set settings on startup for jaws

### DIFF
--- a/src/runner/at-driver.js
+++ b/src/runner/at-driver.js
@@ -32,8 +32,8 @@ export async function createATDriver({
   const socket = new ws(url);
   const driver = new ATDriver({ socket, log });
   await driver.ready;
-  const settings = globalSettings[this._capabilities.atName];
-  if (settings) await this.setSettings(settings);
+  const settings = globalSettings[(await driver.getCapabilities()).atName];
+  if (settings) await driver.setSettings(settings);
   abortSignal.then(() => driver.quit());
   return driver;
 }

--- a/src/runner/at-driver.js
+++ b/src/runner/at-driver.js
@@ -147,11 +147,9 @@ export class ATDriver {
    * @param {[{name: string, value: string | boolean}]} settings
    */
   async setSettings(settings) {
-    if (settings?.length) {
-      const { atName } = await this.getCapabilities();
-      const method = atName == 'nvda' ? 'nvda:settings.setSettings' : 'settings.setSettings';
-      return this._send({ method, params: { settings } });
-    }
+    const { atName } = await this.getCapabilities();
+    const method = atName == 'nvda' ? 'nvda:settings.setSettings' : 'settings.setSettings';
+    return this._send({ method, params: { settings } });
   }
 }
 

--- a/src/runner/at-driver.js
+++ b/src/runner/at-driver.js
@@ -4,7 +4,7 @@ import { iterateEmitter } from '../shared/iterate-emitter.js';
 import { RunnerMessage } from './messages.js';
 
 const globalSettings = {
-  jaws: [
+  JAWS: [
     { name: 'jcf:default:HTML:SayAllOnDocumentLoad', value: '0' },
     { name: 'jcf:default:options:TypingEcho', value: '0' },
     { name: 'jcf:default:options:DisplayStartupWizard', value: '0' },

--- a/src/runner/driver-test-runner.js
+++ b/src/runner/driver-test-runner.js
@@ -156,10 +156,9 @@ export class DriverTestRunner {
 
     if (atName == 'NVDA') {
       // disable the "beeps" when switching focus/browse mode, forces it to speak the mode after switching
-      await this.atDriver._send({
-        method: 'nvda:settings.setSettings',
-        params: { settings: [{ name: 'virtualBuffers.passThroughAudioIndication', value: false }] },
-      });
+      await this.atDriver.setSettings([
+        { name: 'virtualBuffers.passThroughAudioIndication', value: false },
+      ]);
 
       try {
         for (const setting of settingsArray) {
@@ -182,12 +181,9 @@ export class DriverTestRunner {
         }
       } finally {
         // turn the "beeps" back on so mode switches won't be spoken (default setting)
-        await this.atDriver._send({
-          method: 'nvda:settings.setSettings',
-          params: {
-            settings: [{ name: 'virtualBuffers.passThroughAudioIndication', value: true }],
-          },
-        });
+        await this.atDriver.setSettings([
+          { name: 'virtualBuffers.passThroughAudioIndication', value: true },
+        ]);
       }
     } else if (atName == 'JAWS') {
       for (const setting of settingsArray) {
@@ -211,12 +207,7 @@ export class DriverTestRunner {
         // set the setting and collect the mode switch utterance if we are in the incorrect mode.
         let unknownCollected = '';
         const speechResponse = await this._collectSpeech(this.timesOption.modeSwitch, () =>
-          this.atDriver._send({
-            method: 'settings.setSettings',
-            params: {
-              settings: [{ name: 'cursor', value }],
-            },
-          })
+          this.atDriver.setSettings([{ name: 'cursor', value }])
         );
         while (speechResponse.length) {
           const lastMessage = speechResponse.shift().trim();


### PR DESCRIPTION
Adds a `setSettings` method to the at driver, and a `globalSettings[atName]` constant to hold the global startup settings params.