### PR TITLE
Removing `nvda:` from settings api

### DIFF
--- a/src/runner/at-driver.js
+++ b/src/runner/at-driver.js
@@ -147,9 +147,7 @@ export class ATDriver {
    * @param {[{name: string, value: string | boolean}]} settings
    */
   async setSettings(settings) {
-    const { atName } = await this.getCapabilities();
-    const method = atName == 'nvda' ? 'nvda:settings.setSettings' : 'settings.setSettings';
-    return this._send({ method, params: { settings } });
+    return this._send({ method: 'settings.setSettings', params: { settings } });
   }
 }
 


### PR DESCRIPTION
This PR cleans up the setSettings command with the new updates from https://github.com/Prime-Access-Consulting/nvda-at-automation/pull/57

https://github.com/bocoup/aria-at-gh-actions-helper-dev/actions/runs/17287098543/job/49066223601#step:17:146 is a run of the automation using this commit with the new PAC driver.

After merging this, let me know when you've published a new version number and I'll have a PR ready for the automation helper.